### PR TITLE
Responsive tweaks to specialties section.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -42,8 +42,7 @@
       </div>
     </nav>
 
-    <img src="./images/logo_white.svg" alt="Clio + Calliope logo" height="auto" width="80%" style="max-width: 960px;margin: 36px 0;"
-    />
+    <img src="./images/logo_white.svg" alt="Clio + Calliope logo" height="auto" width="80%" style="max-width: 960px;margin: 36px 0;"/>
     <h2 class="subtitle">
       We create beautiful websites and mobile apps.
     </h2>
@@ -55,7 +54,7 @@
     <section id="lead-section" class="inset-960 center">
       <p class="lead">Our expert team creates clean, beautiful, and easy-to-use web and mobile applications.</p>
       <p class="lead">Let's create something together.</p>
-      <div class="vertical-space-xl"></div>
+      <div class="vertical-space-md"></div>
       <a href="contact.html" class="button uppercase">Work with us</a>
     </section>
 
@@ -108,6 +107,7 @@
       <div class="inset-1220">
         <p class="lead center">We constantly push our skills to stay current with emerging technologies needed for modern applications.</p>
 
+        <div class="vertical-space-md"></div>
         <h1 class="uppercase section-title">Specialties</h1>
         <ul class="specialties-list">
           <li>Branding</li>
@@ -155,9 +155,9 @@
     <section id="contact" class="center inset-1220">
       <h1 class="uppercase section-title">Let's get started</h1>
       <p class="lead">Every project is unique. Whatever your goals, we work closely with you to bring your project to life.</p>
-      <div class="vertical-space-xl"></div>
+      <div class="vertical-space-md"></div>
       <a href="contact.html" class="button uppercase">Work with us</a>
-      <div class="vertical-space-xl"></div>
+      <div class="vertical-space-md"></div>
     </section>
     <!-- END Contact us section -->
   </main>

--- a/app/index.html
+++ b/app/index.html
@@ -54,7 +54,7 @@
     <section id="lead-section" class="inset-960 center">
       <p class="lead">Our expert team creates clean, beautiful, and easy-to-use web and mobile applications.</p>
       <p class="lead">Let's create something together.</p>
-      <div class="vertical-space-md"></div>
+      <div class="vertical-space-xl"></div>
       <a href="contact.html" class="button uppercase">Work with us</a>
     </section>
 
@@ -155,9 +155,9 @@
     <section id="contact" class="center inset-1220">
       <h1 class="uppercase section-title">Let's get started</h1>
       <p class="lead">Every project is unique. Whatever your goals, we work closely with you to bring your project to life.</p>
-      <div class="vertical-space-md"></div>
+      <div class="vertical-space-xl"></div>
       <a href="contact.html" class="button uppercase">Work with us</a>
-      <div class="vertical-space-md"></div>
+      <div class="vertical-space-xl"></div>
     </section>
     <!-- END Contact us section -->
   </main>

--- a/app/scss/_base.scss
+++ b/app/scss/_base.scss
@@ -1,11 +1,24 @@
 @import 'variables';
 
+// TODO: Remove this mix-in once everything is switched to 'above'
 @mixin breakpoint($point) {
   @if $point == medium-screen {
     @media (max-width: 960px) { @content; }
   }
   @else if $point == small-screen {
     @media (max-width: 600px) { @content; }
+  }
+}
+
+@mixin above($point) {
+  @if $point == small-screen {
+    @media (min-width: 750px) { @content; }
+  }
+  @else if $point == medium-screen {
+    @media (min-width: 960px) { @content; }
+  }
+  @else if $point == large-screen {
+    @media (min-width: 1080px) { @content; }
   }
 }
 
@@ -26,13 +39,14 @@ body {
   margin: 0;
   font-family: $font-primary;
   color: $black;
-  font-size: 137%;
-  @include breakpoint(medium-screen) {
+  font-size: 100%;
+  @include above(medium-screen) {
     font-size: 120%;
   }
-  @include breakpoint(small-screen) {
-    font-size: 100%;
+  @include above(large-screen) {
+    font-size: 137%;
   }
+
 }
 
 h1 {

--- a/app/scss/_base.scss
+++ b/app/scss/_base.scss
@@ -15,6 +15,7 @@
 .center {text-align: center;}
 .vertical-space-sm {height: $sm;}
 .vertical-space-md {height: $md;}
+.vertical-space-xl {height: $xl;}
 .inset-960 {max-width: 960px;}
 .inset-1220 {max-width: 1220px;}
 
@@ -36,7 +37,7 @@ body {
 
 h1 {
   font-family: $font-accent;
-  margin: $md;
+  margin: $md 0;
 }
 
 p {

--- a/app/scss/_base.scss
+++ b/app/scss/_base.scss
@@ -14,7 +14,7 @@
 .right {text-align: right;}
 .center {text-align: center;}
 .vertical-space-sm {height: $sm;}
-.vertical-space-xl {height: $xl;}
+.vertical-space-md {height: $md;}
 .inset-960 {max-width: 960px;}
 .inset-1220 {max-width: 1220px;}
 
@@ -36,6 +36,7 @@ body {
 
 h1 {
   font-family: $font-accent;
+  margin: $md;
 }
 
 p {
@@ -47,8 +48,14 @@ p {
     color: $teal;
     font-size: 2em;
     font-weight: 400;
+    line-height: 1.5;
+    margin: $xl $sm $md $sm;
     @include breakpoint(small-screen) {
       font-size: 1.5em;
+      margin: $lg $md $sm $sm;
+    }
+    @media screen and (min-width: 1000px) {
+      margin: $xxl $xl $sm $sm;
     }
   }
 }

--- a/app/scss/components/_button.scss
+++ b/app/scss/components/_button.scss
@@ -10,6 +10,7 @@
   text-decoration: none;
 
   &:hover {
-    background-color: darken($orange, 10%);
+    background-color: lighten($orange, 2%);
+    transition: background-color 500ms ease;
   }
 }

--- a/app/scss/components/_header.scss
+++ b/app/scss/components/_header.scss
@@ -33,5 +33,17 @@ header {
       font-weight: bold;
       margin: 0;
     }
+
+    @media screen and (max-width: 960px) {
+      .title {
+        font-size: calc(24px + 10vw);
+      }
+      .subtitle {
+        font-size: calc(16px + 2vw);
+      }
+      .lead {
+        font-size: calc(14px + 1vw);
+      }
+    }
   }
 }

--- a/app/scss/components/_section.scss
+++ b/app/scss/components/_section.scss
@@ -23,18 +23,20 @@ section {
     color: $mint;
   }
   @include breakpoint(small-screen) {
-    padding: $lg $sm;
+    padding: $lg $md;
   }
 }
 
 section.gradient-fill {
   background-color: #0AA8BE; // fallback for old browsers
   background-image: linear-gradient(to right top, #0686ad 0%, #2bbbae 100%);
-  clip-path: polygon(0% 0%, 50% 8%, 100% 0%, 100% 92%, 50% 100%, 0% 92%);
   width: 100vw;
   box-sizing: border-box;
-  padding-top: $xxl;
-
+  padding-top: $xl;
+  clip-path: polygon(0% 0%, 50% 5%, 100% 0%, 100% 92%, 50% 98%, 0% 92%);
+  @media screen and (min-width: 1000px) {
+    clip-path: polygon(0% 0%, 50% 8%, 100% 0%, 100% 91%, 50% 100%, 0% 91%);
+  }
   .inset-1220 {
     max-width: 1220px;
   }

--- a/app/scss/style.scss
+++ b/app/scss/style.scss
@@ -3,7 +3,7 @@
 .service {
   align-items: center;
   display: flex;
-  margin-bottom: $xxl;
+  margin-bottom: $xl;
 
   .service-description {
     padding: $lg $xxl $lg $lg;
@@ -31,6 +31,7 @@
 }
 
 .specialties-list {
+  width: 100%;
   display: flex;
   list-style: none;
   flex-wrap: wrap;
@@ -38,15 +39,17 @@
   padding: 0;
 
   li {
-    width: 240px;
-    line-height: 42px;
+    box-sizing: border-box;
+    margin: $sm 0 0 $sm;
+    line-height: $lg;
+    text-align: center;
   }
 }
 
 .technologies-list {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: space-evenly;
   list-style: none;
   margin: $lg -16px $xl;
   padding: 0;
@@ -64,7 +67,29 @@
   }
 }
 
+@media screen and (min-width: 1080px) {
+  .specialties-list {
+    &:after {
+      content: "";
+      flex: auto;
+    }
+    li {
+      width: calc(25% - 8px);
+      text-align: center;
+    }
+  }
+}
 @media screen and (max-width: 1080px) {
+  .specialties-list {
+    &:after {
+      content: "";
+      flex: auto;
+    }
+    li {
+      width: calc(25% - 8px);
+      text-align: center;
+    }
+  }
   .service .service-description {
     padding: $lg 0 $lg $lg;
   }
@@ -83,6 +108,17 @@
     }
     .lead {
       font-size: calc(14px + 1vw);
+    }
+  }
+  .specialties-list {
+    &:after {
+      content: "";
+      flex: auto;
+    }
+    li {
+      width: calc(33.33333% - 8px);
+      font-size: 0.9em;
+      text-align: center;
     }
   }
 }
@@ -115,15 +151,26 @@
       }
     }
   }
+  .specialties-list {
+    &:after {
+      content: "";
+      flex: auto;
+    }
+    li {
+      width: calc(33.33333% - 8px);
+      font-size: 0.9em;
+      text-align: center;
+    }
+  }
 }
 
 @media screen and (max-width: 600px) {
+  .specialties-list li {
+    width: calc(50% - 8px);
+    text-align: center;
+  }
   .technologies-list li {
     width: 102px;
-  }
-  .specialties-list li {
-    width: 180px;
-    text-align: center;
   }
   .service .service-description, .service.reverse .service-description {
     font-size: 1.2em;

--- a/app/scss/style.scss
+++ b/app/scss/style.scss
@@ -5,8 +5,26 @@
   display: flex;
   margin-bottom: $xl;
 
+  @media screen and (max-width: 750px) {
+    flex-direction: column;
+    align-items: center;
+    display: flex;
+  }
+
   .service-description {
     padding: $lg $xxl $lg $lg;
+
+    @media screen and (max-width: 600px) {
+      font-size: 1.2em;
+    }
+    @media screen and (max-width: 750px) {
+      padding: 0;
+      max-width: 500px;
+    }
+    @media screen and (max-width: 1080px) {
+      padding: $lg 0 $lg $lg;
+    }
+
     h2 {
       margin: 16px 0;
     }
@@ -17,15 +35,39 @@
     height: auto;
     padding: 0 $md 0 0;
     width: 50%;
+
+    @media screen and (max-width: 750px) {
+      height: auto;
+      padding: 0;
+      max-width: 500px;
+      width: 100%;
+    }
   }
 
   &.reverse {
     flex-direction: row-reverse;
+    @media screen and (max-width: 750px) {
+      flex-direction: column;
+    }
+
     .service-description {
       padding: $lg $lg $lg $xxl;
+      @media screen and (max-width: 750px) {
+        padding: 0;
+      }
+      @media screen and (max-width: 600px) {
+        font-size: 1.2em;
+      }
+      @media screen and (max-width: 1080px) {
+        padding: $lg $lg $lg 0;
+      }
     }
+
     img {
       padding: 0 0 0 $md;
+      @media screen and (max-width: 750px) {
+        padding: 0;
+      }
     }
   }
 }
@@ -35,14 +77,37 @@
   display: flex;
   list-style: none;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: space-around;
   padding: 0;
+
+  &:after {
+    content: "";
+    flex: auto;
+  }
 
   li {
     box-sizing: border-box;
-    margin: $sm 0 0 $sm;
+    margin-top: $sm;
     line-height: $lg;
     text-align: center;
+    width: 50%;
+    text-align: center;
+
+    &:after {
+      content: "";
+      flex: auto;
+    }
+
+    @media screen and (min-width: 750px) {
+      width: 33.33333%;
+      font-size: 0.9em;
+      text-align: center;
+    }
+
+    @media screen and (min-width: 1080px) {
+      width: 25%;
+      text-align: center;
+    }
   }
 }
 
@@ -61,118 +126,15 @@
     line-height: 42px;
     margin: $md;
     width: 140px;
+
+    @media screen and (max-width: 600px) {
+      width: 102px;
+    }
+
     i.fa {
       font-size: 50px;
     }
   }
 }
 
-@media screen and (min-width: 1080px) {
-  .specialties-list {
-    &:after {
-      content: "";
-      flex: auto;
-    }
-    li {
-      width: calc(25% - 8px);
-      text-align: center;
-    }
-  }
-}
-@media screen and (max-width: 1080px) {
-  .specialties-list {
-    &:after {
-      content: "";
-      flex: auto;
-    }
-    li {
-      width: calc(25% - 8px);
-      text-align: center;
-    }
-  }
-  .service .service-description {
-    padding: $lg 0 $lg $lg;
-  }
-  .service.reverse .service-description {
-    padding: $lg $lg $lg 0;
-  }
-}
 
-@media screen and (max-width: 960px) {
-  header.hero {
-    .title {
-      font-size: calc(24px + 10vw);
-    }
-    .subtitle {
-      font-size: calc(16px + 2vw);
-    }
-    .lead {
-      font-size: calc(14px + 1vw);
-    }
-  }
-  .specialties-list {
-    &:after {
-      content: "";
-      flex: auto;
-    }
-    li {
-      width: calc(33.33333% - 8px);
-      font-size: 0.9em;
-      text-align: center;
-    }
-  }
-}
-
-@media screen and (max-width: 750px) {
-  .service {
-    flex-direction: column;
-    align-items: center;
-    display: flex;
-
-    .service-description {
-      padding: 0;
-      max-width: 500px;
-    }
-
-    img {
-      height: auto;
-      padding: 0;
-      max-width: 500px;
-      width: 100%;
-    }
-
-    &.reverse {
-      flex-direction: column;
-      .service-description {
-        padding: 0;
-      }
-      img {
-        padding: 0;
-      }
-    }
-  }
-  .specialties-list {
-    &:after {
-      content: "";
-      flex: auto;
-    }
-    li {
-      width: calc(33.33333% - 8px);
-      font-size: 0.9em;
-      text-align: center;
-    }
-  }
-}
-
-@media screen and (max-width: 600px) {
-  .specialties-list li {
-    width: calc(50% - 8px);
-    text-align: center;
-  }
-  .technologies-list li {
-    width: 102px;
-  }
-  .service .service-description, .service.reverse .service-description {
-    font-size: 1.2em;
-  }
-}

--- a/app/scss/style.scss
+++ b/app/scss/style.scss
@@ -98,13 +98,13 @@
       flex: auto;
     }
 
-    @media screen and (min-width: 750px) {
+    @include above(small-screen) {
       width: 33.33333%;
       font-size: 0.9em;
       text-align: center;
     }
 
-    @media screen and (min-width: 1080px) {
+    @include above(large-screen) {
       width: 25%;
       text-align: center;
     }
@@ -125,10 +125,10 @@
     flex-direction: column;
     line-height: 42px;
     margin: $md;
-    width: 140px;
+    width: 102px;
 
-    @media screen and (max-width: 600px) {
-      width: 102px;
+    @include above(small-screen) {
+      width: 140px;
     }
 
     i.fa {


### PR DESCRIPTION
Addresses #7.

I'm taking the approach of modifying each section for responsive tweaks to try to keep these granular and prevent gargantuan, tangled PRs. We'll see how successful I am 😛 

One thing I noticed as I was doing this work is something I think you mentioned last week regarding mobile-first design—I usually prefer to have breakpoints set using `min-width` rather than `max-width`, that way any CSS not scoped to a breakpoint serves as "mobile first", with any changes to styles happening as you size up. Using `max-width` means that you have to set CSS properties explicitly a few more times than you do with `min-width`, so it's slightly less DRY. Not sure if I explained that very coherently. WORDS HARD. ha. I think I recall you mentioning this issue last week so it's likely something you're already aware of. 

All of that is to say: I didn't take the time to refactor to switch to `min-width` as part of this PR, but I'm happy to do that work if you think it's worth making the switch (I do). I was also hesitant to go ahead and refactor in this PR given that I haven't tweaked the other sections yet and there may be breakpoint-y code that means refactoring one section at a time will be tough.

Let me know what you think about the refactor, and if it sounds good to you, I can make some issues and PRs for that work.

"Before" shots are `master`, "After" shots are this PR.

# Very small width
### Before
![screen shot 2017-11-08 at 11 10 13 am](https://user-images.githubusercontent.com/1529366/32562983-acd6cd18-c475-11e7-83c8-6fc8f4e2a4ee.png)
![screen shot 2017-11-08 at 11 10 21 am](https://user-images.githubusercontent.com/1529366/32562984-acf3a4d8-c475-11e7-9f8a-2a4352e777d2.png)

### After
![screen shot 2017-11-08 at 11 00 25 am](https://user-images.githubusercontent.com/1529366/32562454-5f2856c8-c474-11e7-9228-7c2604ae31de.png)
![screen shot 2017-11-08 at 11 00 34 am](https://user-images.githubusercontent.com/1529366/32562455-5f3b5b60-c474-11e7-9402-374fe54aea18.png)

# Small width
### Before
![screen shot 2017-11-08 at 11 10 41 am](https://user-images.githubusercontent.com/1529366/32562985-ad049b80-c475-11e7-9749-90442c82332f.png)

### After
![screen shot 2017-11-08 at 11 00 47 am](https://user-images.githubusercontent.com/1529366/32562456-5f57d862-c474-11e7-8a00-4062ece025c4.png)

# Medium width
### Before
![screen shot 2017-11-08 at 11 10 56 am](https://user-images.githubusercontent.com/1529366/32562986-ad191c68-c475-11e7-922c-975f40c2c051.png)
![screen shot 2017-11-08 at 11 11 04 am](https://user-images.githubusercontent.com/1529366/32562987-ad2e1366-c475-11e7-8040-aefd1ea25c52.png)

### After
![screen shot 2017-11-08 at 11 01 03 am](https://user-images.githubusercontent.com/1529366/32562457-5f699160-c474-11e7-9bc0-7493f570515c.png)


# Large width
### Before
![screen shot 2017-11-08 at 11 11 15 am](https://user-images.githubusercontent.com/1529366/32562988-ad48c5d0-c475-11e7-819c-02bdfc8c901f.png)
![screen shot 2017-11-08 at 11 11 23 am](https://user-images.githubusercontent.com/1529366/32562989-ad69e486-c475-11e7-8917-e016b218d5e5.png)

### After
![screen shot 2017-11-08 at 11 01 17 am](https://user-images.githubusercontent.com/1529366/32562458-5f882b98-c474-11e7-99e5-c3f118a232b4.png)

# Extra Large width
### Before
![screen shot 2017-11-08 at 11 11 31 am](https://user-images.githubusercontent.com/1529366/32562991-ad859ac8-c475-11e7-989f-f8d63f673393.png)
![screen shot 2017-11-08 at 11 11 42 am](https://user-images.githubusercontent.com/1529366/32562996-adba8c4c-c475-11e7-9651-a739edb0b649.png)

### After
![screen shot 2017-11-08 at 11 01 26 am](https://user-images.githubusercontent.com/1529366/32562459-5f996f70-c474-11e7-8d2b-8b16b998599b.png)
 Connects #32